### PR TITLE
simple script.py

### DIFF
--- a/src/framework/command_router.ts
+++ b/src/framework/command_router.ts
@@ -24,12 +24,7 @@ export default class CommandRouter implements CommandHandler {
 
   onCommandSystem (command: CommandSystem, resolve: (response: Response) => void): void {
     this.bridge.send(command)
-
-    if (isCommandSystemExit(command)) {
-      console.log('[CommandRouter] Application exit')
-    } else {
-      resolve({ __type__: 'Response', command, payload: { __type__: 'PayloadVoid', value: undefined } })
-    }
+    resolve({ __type__: 'Response', command, payload: { __type__: 'PayloadVoid', value: undefined } })
   }
 
   onCommandUI (command: CommandUI, reject: (reason?: any) => void): void {

--- a/src/framework/processing/py/port/api/props.py
+++ b/src/framework/processing/py/port/api/props.py
@@ -51,12 +51,9 @@ class PropsUIFooter:
         progressPercentage: float indicating the progress in the flow
     """
 
-    progressPercentage: float
-
     def toDict(self):
         dict = {}
         dict["__type__"] = "PropsUIFooter"
-        dict["progressPercentage"] = self.progressPercentage
         return dict
 
 
@@ -298,7 +295,7 @@ class PropsUIPageDonation:
         | PropsUIPromptConfirm
         | PropsUIPromptQuestionnaire
     )
-    footer: PropsUIFooter
+    footer: Optional[PropsUIFooter] = None
 
     def toDict(self):
         dict = {}
@@ -306,7 +303,7 @@ class PropsUIPageDonation:
         dict["platform"] = self.platform
         dict["header"] = self.header.toDict()
         dict["body"] = self.body.toDict()
-        dict["footer"] = self.footer.toDict()
+        dict["footer"] = self.footer.toDict() if self.footer else None
         return dict
 
 

--- a/src/framework/processing/py/port/script.py
+++ b/src/framework/processing/py/port/script.py
@@ -1,863 +1,165 @@
-import itertools
 import port.api.props as props
-from port.api.commands import CommandSystemDonate, CommandUIRender
+from port.api.commands import (CommandSystemDonate, CommandUIRender, CommandSystemExit)
 
 import pandas as pd
 import zipfile
-import json
-import datetime
-import pytz
-import fnmatch
-from collections import defaultdict, namedtuple
-from contextlib import suppress
 
-##########################
-# Instagram file processing #
-##########################
-
-filter_start = datetime.datetime(1990, 1, 1)
-filter_end = datetime.datetime(2025, 1, 1)
-
-datetime_format = "%Y-%m-%d %H:%M:%S"
-
-
-def parse_datetime(value):
-    utc_datetime = datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
-    uk_timezone = pytz.timezone("Europe/London")
-    return uk_timezone.normalize(utc_datetime.astimezone(uk_timezone))
-
-
-def get_in(data_dict, *key_path):
-    for k in key_path:
-        data_dict = data_dict.get(k, None)
-        if data_dict is None:
-            return None
-    return data_dict
-
-
-def get_list(data_dict, *key_path):
-    result = get_in(data_dict, *key_path)
-    if result is None:
-        return []
-    return result
-
-
-def get_dict(data_dict, *key_path):
-    result = get_in(data_dict, *key_path)
-    if result is None:
-        return {}
-    return result
-
-
-def get_string(data_dict, *key_path):
-    result = get_in(data_dict, *key_path)
-    if result is None:
-        return ""
-    return result
-
-
-def cast_number(data_dict, *key_path):
-    value = get_in(data_dict, *key_path)
-    if value is None or value == "None":
-        return 0
-    return value
-
-
-def get_activity_video_browsing_list_data(data):
-    return get_list(data, "Activity", "Video Browsing History", "VideoList")
-
-
-def get_comment_list_data(data):
-    return get_in(data, "Comment", "Comments", "CommentsList")
-
-
-def filter_timestamps(timestamps):
-    for timestamp in timestamps:
-        if timestamp < filter_start or timestamp > filter_end:
-            continue
-        yield timestamp
-
-
-def get_count_by_date_key(timestamps, key_func):
-    """Returns a dict of the form (key, count)
-
-    The key is determined by the key_func, which takes a datetime object and
-    returns an object suitable for sorting and usage as a dictionary key.
-
-    The returned list is sorted by key.
-    """
-    item_count = defaultdict(int)
-    for timestamp in timestamps:
-        item_count[key_func(timestamp)] += 1
-    return sorted(item_count.items())
-
-
-def get_all_first(items):
-    return (i[0] for i in items)
-
-
-def hourly_key(date):
-    return date.replace(minute=0, second=0, microsecond=0)
-
-
-def daily_key(date):
-    return date.date()
-
-
-# =====================
-def glob(zipfile, pattern):
-    return fnmatch.filter(zipfile.namelist(), pattern)
-
-
-def glob_json(zipfile, pattern):
-    for name in glob(zipfile, pattern):
-        with zipfile.open(name) as f:
-            yield json.load(f)
-
-
-# =====================
-
-
-def get_sessions(timestamps):
-    """Returns a list of tuples of the form (start, end, duration)
-
-    The start and end are datetime objects, and the duration is a timedelta
-    object.
-    """
-    timestamps = list(sorted(timestamps))
-    if len(timestamps) == 0:
-        return []
-    if len(timestamps) == 1:
-        return [(timestamps[0], timestamps[0], datetime.timedelta(0))]
-
-    sessions = []
-    start = timestamps[0]
-    end = timestamps[0]
-    for prev, cur in zip(timestamps, timestamps[1:]):
-        if cur - prev > datetime.timedelta(minutes=5):
-            sessions.append((start, end, end - start))
-            start = cur
-        end = cur
-    sessions.append((start, end, end - start))
-    return sessions
-
-
-def filtered_count(data, *key_path):
-    items = get_list(data, *key_path)
-    filtered_items = get_date_filtered_items(items)
-    return len(list(filtered_items))
-
-
-def get_chat_history(data):
-    return get_dict(data, "Direct Messages", "Chat History", "ChatHistory")
-
-
-def flatten_chat_history(history):
-    return itertools.chain(*history.values())
-
-
-def filter_by_key(items, key, value):
-    return filter(lambda item: item[key] == value, items)
-
-
-def exclude_by_key(items, key, value):
-    """
-    Return a filtered list where items that match key & value are excluded.
-    """
-    return filter(lambda item: item[key] != value, items)
-
-
-def map_to_timeslot(series):
-    return series.map(lambda hour: f"{hour}-{hour+1}")
-
-
-def count_items(zipfile, pattern, key):
-    count = 0
-    for data in glob_json(zipfile, pattern):
-        # Some files have dictionary, others a list of dictionaries. Normalize
-        # this to always a list so the rest of the code works regardless.
-        if isinstance(data, dict):
-            data = [data]
-        for item in data:
-            count += len(item[key])
-    return count
-
-
-def count_posts(zipfile):
-    return sum(len(data) for data in glob_json(zipfile, "content/posts_*.json"))
-
-
-def count_messages(zipfile):
-    counts = {"sent": 0, "received": 0}
-    for data in glob_json(zipfile, "messages/inbox/**/message_*.json"):
-        donating_user = get_donating_user(data)
-        for message in data["messages"]:
-            key = "sent" if message["sender_name"] == donating_user else "received"
-            counts[key] += 1
-    return counts
-
-
-def get_donating_user(data):
-    participants = data["participants"]
-    return participants[len(participants) - 1]["name"]
-
-
-def extract_summary_data(zipfile):
-    message_counts = count_messages(zipfile)
-    summary_data = {
-        "Description": [
-            "Followers",
-            "Following",
-            "Posts",
-            "Comments posted",
-            "Videos watched",
-            "Posts viewed",
-            "Messages sent",
-            "Messages received",
-            "Ads viewed",
-        ],
-        "Number": [
-            count_items(
-                zipfile, "followers_and_following/followers_*.json", "string_list_data"
-            ),
-            count_items(
-                zipfile,
-                "followers_and_following/following.json",
-                "relationships_following",
-            ),
-            count_posts(zipfile),
-            count_items(
-                zipfile, "comments/post_comments.json", "comments_media_comments"
-            ),
-            count_items(
-                zipfile,
-                "ads_and_topics/videos_watched.json",
-                "impressions_history_videos_watched",
-            ),
-            count_items(
-                zipfile,
-                "ads_and_topics/posts_viewed.json",
-                "impressions_history_posts_seen",
-            ),
-            message_counts["sent"],
-            message_counts["received"],
-            count_items(
-                zipfile,
-                "ads_and_topics/ads_viewed.json",
-                "impressions_history_ads_seen",
-            ),
-        ],
-    }
-
-    visualizations = []
-
-    return ExtractionResult(
-        "instagram_summary",
-        props.Translatable(
-            {"en": "Summary information", "nl": "Samenvatting gegevens"}
-        ),
-        pd.DataFrame(summary_data),
-        visualizations,
-    )
-
-
-def extract_direct_message_activity(zipfile):
-    counter = itertools.count()
-    person_ids = defaultdict(lambda: next(counter))
-    sender_ids = []
-    timestamps = []
-    for data in glob_json(zipfile, "messages/inbox/**/message_*.json"):
-        # Ensure the donating user is the first to get an ID
-        donating_user = get_donating_user(data)
-        person_ids[donating_user]
-        for message in data["messages"]:
-            sender_ids.append(person_ids[message["sender_name"]])
-            timestamps.append(parse_datetime(message["timestamp_ms"] / 1000))
-    df = pd.DataFrame({"Anonymous ID": sender_ids, "Sent": timestamps})
-    df["Sent"] = pd.to_datetime(df["Sent"]).dt.strftime("%Y-%m-%d %H:%M")
-
-    visualizations = [
-        dict(
-            title={
-                "en": "Direct message activity over time",
-                "nl": "Direct message activiteit in de loop van de tijd",
-            },
-            type="area",
-            group=dict(column="Sent", dateFormat="auto"),
-            values=[
-                dict(
-                    label="Messages",
-                    column="Anonymous ID",
-                    aggregate="count",
-                    addZeroes=True,
-                )
-            ],
-        )
-    ]
-
-    return ExtractionResult(
-        "instagram_direct_message_activity",
-        props.Translatable(
-            {"en": "Direct message activity", "nl": "Bericht activiteit"}
-        ),
-        df,
-        visualizations,
-    )
-
-
-def extract_comment_activity(zipfile):
-    timestamps = []
-    for data in glob_json(zipfile, "comments/post_comments.json"):
-        for item in data["comments_media_comments"]:
-            timestamps.append(
-                parse_datetime(item["string_map_data"]["Time"]["timestamp"])
-            )
-    df = pd.DataFrame({"Posted": timestamps})
-    df = df.sort_values("Posted")
-    df["Posted"] = pd.to_datetime(df["Posted"]).dt.strftime("%Y-%m-%d %H:%M")
-
-    visualizations = [
-        dict(
-            title={
-                "en": "Comment activity over time",
-                "nl": "Comment activiteit in de loop van de tijd",
-            },
-            type="area",
-            group=dict(column="Posted", dateFormat="auto"),
-            values=[
-                dict(
-                    label="Comment activity",
-                    aggregate="count",
-                    addZeroes=True,
-                )
-            ],
-        )
-    ]
-
-    return ExtractionResult(
-        "instagram_comment_activity",
-        props.Translatable({"en": "Comment activity", "nl": "Commentaar activiteit"}),
-        df,
-        visualizations,
-    )
-
-
-def extract_posts_liked(zipfile):
-    urls = []
-    timestamps = []
-    for data in glob_json(zipfile, "likes/liked_posts.json"):
-        for item in data["likes_media_likes"]:
-            info = item["string_list_data"][0]
-            timestamps.append(parse_datetime(info["timestamp"]))
-            urls.append(info["href"])
-    df = pd.DataFrame({"Liked": timestamps, "Link": urls})
-    df["Liked"] = pd.to_datetime(df["Liked"]).dt.strftime("%Y-%m-%d %H:%M")
-    df = df.sort_values("Liked")
-
-    visualizations = [
-        dict(
-            title={
-                "en": "Posts like per hour of the day",
-                "nl": "Posts geliked per uur van de dag",
-            },
-            type="bar",
-            group=dict(column="Liked", dateFormat="hour_cycle"),
-            values=[
-                dict(
-                    label="likes",
-                    column="Link",
-                    aggregate="count",
-                    addZeroes=True,
-                )
-            ],
-        )
-    ]
-
-    return ExtractionResult(
-        "instagram_posts_liked",
-        props.Translatable({"en": "Posts Liked", "nl": "Geliked"}),
-        df,
-        visualizations,
-    )
-
-
-def flatten_media(items):
-    for item in items:
-        yield from item["media"]
-
-
-def get_creation_timestamps(items):
-    for item in items:
-        yield parse_datetime(item["creation_timestamp"])
-
-
-def get_media_creation_timestamps(items):
-    return get_creation_timestamps(flatten_media(items))
-
-
-def get_content_posts_timestamps(zipfile):
-    for data in glob_json(zipfile, "content/posts_*.json"):
-        yield from get_media_creation_timestamps(data)
-
-
-def get_media_timestamps(zipfile, pattern, key):
-    for data in glob_json(zipfile, pattern):
-        yield from get_media_creation_timestamps(data[key])
-
-
-def df_from_timestamps(timestamps, column):
-    df = pd.DataFrame({"timestamps": timestamps})
-    counts = df.groupby(lambda x: hourly_key(df["timestamps"][x])).size()
-
-    df = counts.reset_index()
-    df.columns = ["timestamp", column]
-    return df
-
-
-def stories_timestamps(zipfile):
-    for data in glob_json(zipfile, "content/stories.json"):
-        for item in data["ig_stories"]:
-            yield parse_datetime(item["creation_timestamp"])
-
-
-def df_from_timestamp_columns(a, b):
-    data_frames = [
-        df_from_timestamps(timestamps, column) for timestamps, column in [a, b]
-    ]
-
-    df = pd.merge(
-        data_frames[0],
-        data_frames[1],
-        left_on="timestamp",
-        right_on="timestamp",
-        how="outer",
-    ).sort_index()
-    df["Date"] = pd.to_datetime(df["timestamp"]).dt.strftime("%Y-%m-%d %H:00:00")
-    df["Timeslot"] = map_to_timeslot(pd.to_datetime(df["timestamp"]).dt.hour)
-    df = df.reset_index(drop=True)
-    df = (
-        df.reindex(columns=["Date", "Timeslot", a[1], b[1]])
-        .reset_index(drop=True)
-        .fillna(0)
-    )
-    df[a[1]] = df[a[1]].astype(int)
-    df[b[1]] = df[b[1]].astype(int)
-    return df
-
-
-def get_video_posts_timestamps(zipfile):
-    return itertools.chain(
-        get_content_posts_timestamps(zipfile),
-        get_media_timestamps(zipfile, "content/igtv_videos.json", "ig_igtv_media"),
-        get_media_timestamps(zipfile, "content/reels.json", "ig_reels_media"),
-    )
-
-
-def extract_video_posts(zipfile):
-    video_timestamps = get_video_posts_timestamps(zipfile)
-    df = df_from_timestamp_columns(
-        (video_timestamps, "Videos"), (stories_timestamps(zipfile), "Stories")
-    )
-
-    visualizations = [
-        dict(
-            title={
-                "en": "Videos and stories over time",
-                "nl": "Video's en stories in de loop van de tijd",
-            },
-            type="line",
-            group=dict(column="Date", dateFormat="auto"),
-            values=[
-                dict(
-                    label="Videos",
-                    column="Videos",
-                    aggregate="sum",
-                    addZeroes=True,
-                ),
-                dict(
-                    label="Stories",
-                    column="Stories",
-                    aggregate="sum",
-                    addZeroes=True,
-                ),
-            ],
-        )
-    ]
-    return ExtractionResult(
-        "instagram_video_posts",
-        props.Translatable({"en": "Posts", "nl": "Posts"}),
-        df,
-        visualizations,
-    )
-
-
-def get_post_comments_timestamps(zipfile):
-    return get_string_map_timestamps(
-        zipfile, "comments/post_comments.json", "comments_media_comments"
-    )
-
-
-def get_string_list_timestamps(zipfile, pattern, key):
-    for data in glob_json(zipfile, pattern):
-        for item in data[key]:
-            yield parse_datetime(item["string_list_data"][0]["timestamp"])
-
-
-def get_string_map_timestamps(zipfile, pattern, key):
-    for data in glob_json(zipfile, pattern):
-        for item in data[key]:
-            yield parse_datetime(item["string_map_data"]["Time"]["timestamp"])
-
-
-def get_likes_timestamps(zipfile):
-    return itertools.chain(
-        get_string_list_timestamps(
-            zipfile, "likes/liked_comments.json", "likes_comment_likes"
-        ),
-        get_string_list_timestamps(
-            zipfile, "likes/liked_posts.json", "likes_media_likes"
-        ),
-    )
-
-
-def extract_comments_and_likes(zipfile):
-    comment_timestamps = get_post_comments_timestamps(zipfile)
-    likes_timestamps = get_likes_timestamps(zipfile)
-    df = df_from_timestamp_columns(
-        (comment_timestamps, "Comments"), (likes_timestamps, "Likes")
-    )
-
-    visualizations = [
-        dict(
-            title={
-                "en": "Comments and likes over time",
-                "nl": "Comments en likes in de loop van de tijd",
-            },
-            type="line",
-            group=dict(column="Date", dateFormat="auto"),
-            values=[
-                dict(
-                    label="Comments",
-                    column="Comments",
-                    aggregate="sum",
-                    addZeroes=True,
-                ),
-                dict(
-                    label="Likes",
-                    column="Likes",
-                    aggregate="sum",
-                    addZeroes=True,
-                ),
-            ],
-        )
-    ]
-
-    return ExtractionResult(
-        "instagram_comments_and_likes",
-        props.Translatable({"en": "Comments and likes", "nl": "Comments en likes"}),
-        df,
-        visualizations,
-    )
-
-
-def extract_viewed(zipfile):
-    df = df_from_timestamp_columns(
-        (
-            get_string_map_timestamps(
-                zipfile,
-                "ads_and_topics/videos_watched.json",
-                "impressions_history_videos_watched",
-            ),
-            "Videos",
-        ),
-        (
-            get_string_map_timestamps(
-                zipfile,
-                "ads_and_topics/posts_viewed.json",
-                "impressions_history_posts_seen",
-            ),
-            "Posts",
-        ),
-    )
-
-    visualizations = [
-        dict(
-            title={
-                "en": "The number of videos and posts you viewed over time",
-                "nl": "Het aantal video's en berichten dat u in de loop van de tijd heeft bekeken",
-            },
-            type="line",
-            group=dict(column="Date", dateFormat="auto"),
-            values=[
-                dict(
-                    label="Videos",
-                    column="Videos",
-                    aggregate="sum",
-                    addZeroes=True,
-                ),
-                dict(
-                    label="Posts",
-                    column="Posts",
-                    aggregate="sum",
-                    addZeroes=True,
-                ),
-            ],
-        )
-    ]
-
-    return ExtractionResult(
-        "instagram_viewed",
-        props.Translatable({"en": "Viewed", "nl": "Viewed"}),
-        df,
-        visualizations,
-    )
-
-
-def extract_session_info(zipfile):
-    timestamps = list(
-        itertools.chain(
-            list(get_video_posts_timestamps(zipfile)),
-            list(stories_timestamps(zipfile)),
-            list(get_post_comments_timestamps(zipfile)),
-            list(get_likes_timestamps(zipfile)),
-        )
-    )
-    sessions = get_sessions(timestamps)
-    df = pd.DataFrame(sessions, columns=["Start", "End", "Duration"])
-    df["Start"] = pd.to_datetime(df["Start"]).dt.strftime("%Y-%m-%d %H:%M")
-    df["Duration (in minutes)"] = (
-        pd.to_timedelta(df["Duration"]).dt.total_seconds() / 60
-    ).round(2)
-    df = df.drop("End", axis=1)
-    df = df.drop("Duration", axis=1)
-
-    visualizations = [
-        dict(
-            title={
-                "en": "Number of minutes spent on Instagram over time",
-                "nl": "Aantal minuten besteed aan Instagram in de loop van de tijd",
-            },
-            type="line",
-            group=dict(column="Start", dateFormat="auto"),
-            values=[
-                dict(
-                    label="Minutes",
-                    column="Duration (in minutes)",
-                    aggregate="sum",
-                    addZeroes=True,
-                )
-            ],
-        )
-    ]
-
-    return ExtractionResult(
-        "instagram_session_info",
-        props.Translatable({"en": "Session information", "nl": "Sessie informatie"}),
-        df,
-        visualizations,
-    )
-
-
-def extract_data(path):
-    extractors = [
-        extract_summary_data,
-        extract_video_posts,
-        extract_comments_and_likes,
-        extract_viewed,
-        extract_session_info,
-        extract_direct_message_activity,
-        extract_comment_activity,
-        extract_posts_liked,
-    ]
-
-    zfile = zipfile.ZipFile(path)
-
-    return [extractor(zfile) for extractor in extractors]
-
-
-######################
-# Data donation flow #
-######################
-
-
-ExtractionResult = namedtuple(
-    "ExtractionResult", ["id", "title", "data_frame", "visualizations"]
-)
-
-
-class SkipToNextStep(Exception):
-    pass
-
-
-class DataDonationProcessor:
-    def __init__(self, platform, mime_types, extractor, session_id):
-        self.platform = platform
-        self.mime_types = mime_types
-        self.extractor = extractor
-        self.session_id = session_id
-        self.progress = 0
-        self.meta_data = []
-
-    def process(self):
-        with suppress(SkipToNextStep):
-            while True:
-                file_result = yield from self.prompt_file()
-
-                self.log(f"extracting file")
-                try:
-                    extraction_result = self.extract_data(file_result.value)
-                except (IOError, zipfile.BadZipFile):
-                    self.log(f"prompt confirmation to retry file selection")
-                    try_again = yield from self.prompt_retry()
-                    if try_again:
-                        continue
-                    return
+def process(session_id: str):
+    platform = "Platform of interest"
+
+    # Start of the data donation flow
+    while True:
+        # Ask the participant to submit a file
+        file_prompt = generate_file_prompt(platform, "application/zip, text/plain")
+        file_prompt_result = yield render_page(platform, file_prompt)
+
+        # If the participant submitted a file: continue
+        if file_prompt_result.__type__ == 'PayloadString':
+
+            # Validate the file the participant submitted
+            # In general this is wise to do 
+            is_data_valid = validate_the_participants_input(file_prompt_result.value)
+
+            # Happy flow:
+            # The file the participant submitted is valid
+            if is_data_valid == True:
+
+                # Extract the data you as a researcher are interested in, and put it in a pandas DataFrame
+                # Show this data to the participant in a table on screen
+                # The participant can now decide to donate
+                extracted_data = extract_the_data_you_are_interested_in(file_prompt_result.value)
+                consent_prompt = generate_consent_prompt(extracted_data)
+                consent_prompt_result = yield render_page(platform, consent_prompt)
+
+                # If the participant wants to donate the data gets donated
+                if consent_prompt_result.__type__ == "PayloadJSON":
+                    yield donate(f"{session_id}-{platform}", consent_prompt_result.value)
+
+                break
+
+            # Sad flow:
+            # The data was not valid, ask the participant to retry
+            if is_data_valid == False:
+                retry_prompt = generate_retry_prompt(platform)
+                retry_prompt_result = yield render_page(platform, retry_prompt)
+
+                # The participant wants to retry: start from the beginning
+                if retry_prompt_result.__type__ == 'PayloadTrue':
+                    continue
+                # The participant does not want to retry or pressed skip
                 else:
-                    if extraction_result is None:
-                        try_again = yield from self.prompt_retry()
-                        if try_again:
-                            continue
-                        else:
-                            return
-                    self.log(f"extraction successful, go to consent form")
-                    yield from self.prompt_consent(extraction_result)
+                    break
 
-    def prompt_retry(self):
-        retry_result = yield render_donation_page(
-            self.platform, retry_confirmation(self.platform), self.progress
-        )
-        return retry_result.__type__ == "PayloadTrue"
+        # The participant did not submit a file and pressed skip
+        else:
+            break
 
-    def prompt_file(self):
-        description = props.Translatable(
-            {
-                "en": f"Please follow the download instructions and choose the file that you stored on your device. Click “Skip” at the right bottom, if you do not have a {self.platform} file. ",
-                "nl": f"Volg de download instructies en kies het bestand dat u opgeslagen heeft op uw apparaat. Als u geen {self.platform} bestand heeft klik dan op “Overslaan” rechts onder.",
-            }
-        )
-        prompt_file = props.PropsUIPromptFileInput(description, self.mime_types)
-        file_result = yield render_donation_page(
-            self.platform, prompt_file, self.progress
-        )
-        if file_result.__type__ != "PayloadString":
-            self.log(f"skip to next step")
-            raise SkipToNextStep()
-        return file_result
-
-    def log(self, message):
-        self.meta_data.append(("debug", f"{self.platform}: {message}"))
-
-    def extract_data(self, file):
-        return self.extractor(file)
-
-    def prompt_consent(self, data):
-        log_title = props.Translatable({"en": "Log messages", "nl": "Log berichten"})
-
-        tables = [
-            props.PropsUIPromptConsentFormTable(
-                table.id,
-                table.title,
-                table.data_frame,
-                None,
-                table.visualizations,
-            )
-            for table in data
-        ]
-        meta_frame = pd.DataFrame(self.meta_data, columns=["type", "message"])
-        meta_table = props.PropsUIPromptConsentFormTable(
-            "log_messages", log_title, meta_frame
-        )
-        description = props.Translatable(
-            {
-                "en": """Determine whether you would like to donate the data below. Carefully check the data and adjust when required. With your donation you contribute to the previously described research. Thank you in advance.
-                    The tables below list the types of data that you can donate from your Instagram package. Please note that you are only donating information about the number of followers, likes, comments, posts, and messages you have sent or received. You will only donate anonymous data. So no information about the content of your posts, messages, or comments is included. You will also not share any information about who you interact with on Instagram (e.g., follow, like, comment on). If you DO NOT want to donate any of the information in the table below, you can select the row and delete it from your data donation in the table below.""",
-            }
-        )
-
-        self.log(f"prompt consent")
-        consent_result = yield render_donation_page(
-            self.platform,
-            props.PropsUIPromptConsentForm(tables, [meta_table], description),
-            self.progress,
-        )
-
-        if consent_result.__type__ == "PayloadJSON":
-            self.log(f"donate consent data")
-            yield donate(f"{self.sessionId}-{self.platform}", consent_result.value)
-
-
-class DataDonation:
-    def __init__(self, platform, mime_types, extractor):
-        self.platform = platform
-        self.mime_types = mime_types
-        self.extractor = extractor
-
-    def __call__(self, session_id):
-        processor = DataDonationProcessor(
-            self.platform, self.mime_types, self.extractor, session_id
-        )
-        yield from processor.process()
-
-
-data_donation = DataDonation("Instagram", "application/zip", extract_data)
-
-
-def process(session_id):
-    progress = 0
-    yield donate(f"{session_id}-tracking", '[{ "message": "user entered script" }]')
-    yield from data_donation(session_id)
+    yield exit_port(0, "Success")
     yield render_end_page()
 
 
+def extract_the_data_you_are_interested_in(zip_file: str) -> pd.DataFrame:
+    """
+    This function extracts the data the researcher is interested in
+
+    In this case we extract from the zipfile:
+    * The file names
+    * The compressed file size
+    * The file size
+
+    You could extract anything here
+    """
+    names = []
+    out = pd.DataFrame()
+
+    try:
+        file = zipfile.ZipFile(zip_file)
+        data = []
+        for name in file.namelist():
+            names.append(name)
+            info = file.getinfo(name)
+            data.append((name, info.compress_size, info.file_size))
+
+        out = pd.DataFrame(data, columns=["File name", "Compressed file size", "File size"])
+
+    except Exception as e:
+        print(f"Something went wrong: {e}")
+
+    return out
+
+
+def validate_the_participants_input(zip_file: str) -> bool:
+    """
+    Check if the participant actually submitted a zipfile
+    Returns True if participant submitted a zipfile, otherwise False
+
+    In reality you need to do a lot more validation.
+    Some things you could check:
+    - Check if the the file(s) are the correct format (json, html, binary, etc.)
+    - If the files are in the correct language
+    """
+
+    try:
+        with zipfile.ZipFile(zip_file) as zf:
+            return True
+    except zipfile.BadZipFile:
+        return False
+
+
 def render_end_page():
+    """
+    Renders a thank you page
+    """
     page = props.PropsUIPageEnd()
     return CommandUIRender(page)
 
 
-def render_donation_page(platform, body, progress):
-    header = props.PropsUIHeader(props.Translatable({"en": platform, "nl": platform}))
-    footer = props.PropsUIFooter(progress)
+def render_page(platform: str, body):
+    """
+    Renders the UI components
+    """
+    header = props.PropsUIHeader(props.Translatable({"en": platform, "nl": platform }))
+    footer = props.PropsUIFooter()
     page = props.PropsUIPageDonation(platform, header, body, footer)
     return CommandUIRender(page)
 
 
-def retry_confirmation(platform):
-    text = props.Translatable(
-        {
-            "en": f"Unfortunately, we cannot process your data. Please make sure that you selected a zip file, and JSON as a file format when downloading your data from Instagram.",
-            "nl": f"Helaas, kunnen we uw {platform} bestand niet verwerken. Weet u zeker dat u het juiste bestand heeft gekozen? Ga dan verder. Probeer opnieuw als u een ander bestand wilt kiezen.",
-        }
-    )
-    ok = props.Translatable({"en": "Try again", "nl": "Probeer opnieuw"})
-    cancel = props.Translatable({"en": "Continue", "nl": "Verder"})
+def generate_retry_prompt(platform: str) -> props.PropsUIPromptConfirm:
+    text = props.Translatable({
+        "en": f"Unfortunately, we cannot process your {platform} file. Continue, if you are sure that you selected the right file. Try again to select a different file.",
+        "nl": f"Helaas, kunnen we uw {platform} bestand niet verwerken. Weet u zeker dat u het juiste bestand heeft gekozen? Ga dan verder. Probeer opnieuw als u een ander bestand wilt kiezen."
+    })
+    ok = props.Translatable({
+        "en": "Try again",
+        "nl": "Probeer opnieuw"
+    })
+    cancel = props.Translatable({
+        "en": "Continue",
+        "nl": "Verder"
+    })
     return props.PropsUIPromptConfirm(text, ok, cancel)
 
 
-def prompt_consent(id, data, meta_data):
-    table_title = props.Translatable(
-        {"en": "Zip file contents", "nl": "Inhoud zip bestand"}
-    )
+def generate_file_prompt(platform, extensions) -> props.PropsUIPromptFileInput:
+    description = props.Translatable({
+        "en": f"Please follow the download instructions and choose the file that you stored on your device. Click “Skip” at the right bottom, if you do not have a {platform} file. ",
+        "nl": f"Volg de download instructies en kies het bestand dat u opgeslagen heeft op uw apparaat. Als u geen {platform} bestand heeft klik dan op “Overslaan” rechts onder."
+    })
+    return props.PropsUIPromptFileInput(description, extensions)
 
-    log_title = props.Translatable({"en": "Log messages", "nl": "Log berichten"})
 
-    data_frame = pd.DataFrame(data, columns=["filename", "compressed size", "size"])
-    table = props.PropsUIPromptConsentFormTable("zip_content", table_title, data_frame)
-    meta_frame = pd.DataFrame(meta_data, columns=["type", "message"])
-    meta_table = props.PropsUIPromptConsentFormTable(
-        "log_messages", log_title, meta_frame
-    )
-
-    return props.PropsUIPromptConsentForm([table], [meta_table])
+def generate_consent_prompt(df: pd.DataFrame) -> props.PropsUIPromptConsentForm:
+    table_title = props.Translatable({
+        "en": "Zip file contents",
+        "nl": "Inhoud zip bestand"
+    })
+    table = props.PropsUIPromptConsentFormTable("zip_contents", table_title, df)
+    return props.PropsUIPromptConsentForm([table], [])
 
 
 def donate(key, json_string):
     return CommandSystemDonate(key, json_string)
 
 
-if __name__ == "__main__":
-    import sys
-
-    if len(sys.argv) > 1:
-        print(extract_data(sys.argv[1]))
-    else:
-        print("please provide a zip file as argument")
+def exit_port(code, info):
+    return CommandSystemExit(code, info)

--- a/src/framework/types/elements.ts
+++ b/src/framework/types/elements.ts
@@ -426,6 +426,14 @@ export function isTranslatable(arg: any): arg is Translatable {
   return isLike<Translatable>(arg, ["translations"])
 }
 
+// FOOTER
+
+export interface PropsUIFooter {
+  __type__: 'PropsUIFooter'
+}
+export function isPropsUIFooter (arg: any): arg is PropsUIFooter {
+  return isInstanceOf<PropsUIFooter>(arg, 'PropsUIFooter', [])
+}
 
 // QUESTION ITEMS
 

--- a/src/framework/types/pages.ts
+++ b/src/framework/types/pages.ts
@@ -1,5 +1,8 @@
 import { isInstanceOf } from '../helpers'
-import { PropsUIHeader } from './elements'
+import { 
+    PropsUIHeader,
+    PropsUIFooter
+} from './elements'
 import { 
     PropsUIPromptFileInput, 
     PropsUIPromptConfirm,
@@ -31,6 +34,7 @@ export interface PropsUIPageDonation {
   platform: string
   header: PropsUIHeader
   body: PropsUIPromptFileInput | PropsUIPromptConfirm | PropsUIPromptConsentForm | PropsUIPromptRadioInput | PropsUIPromptQuestionnaire
+  footer: PropsUIFooter
 }
 export function isPropsUIPageDonation (arg: any): arg is PropsUIPageDonation {
   return isInstanceOf<PropsUIPageDonation>(arg, 'PropsUIPageDonation', ['platform', 'header', 'body'])

--- a/src/framework/visualisation/react/ui/pages/donation_page.tsx
+++ b/src/framework/visualisation/react/ui/pages/donation_page.tsx
@@ -52,7 +52,8 @@ export const DonationPage = (props: Props): JSX.Element => {
     resolve?.({ __type__: 'PayloadFalse', value: false })
   }
 
-  function renderFooter (): JSX.Element {
+  function renderFooter (props: Props): JSX.Element | undefined {
+    if (props.footer != null) {
       return <Footer
       right={
         <div className='flex flex-row'>
@@ -60,11 +61,14 @@ export const DonationPage = (props: Props): JSX.Element => {
           <ForwardButton label={forwardButton} onClick={handleSkip} />
         </div>
       } />
+    } else {
+      return undefined
+    }
   }
 
   const footer: JSX.Element = (
     <>
-      {renderFooter()}
+      {renderFooter(props)}
     </>
   )
 


### PR DESCRIPTION
This one contains  these changes:

- `script.py` is simpler, annotated, and includes comments. This is the same script as I used in a tutorial, it contains all the essential steps that need to happen. *It does not contain visuals yet* I couldnt really think of a way to include them in this simple case
- I changed  `command_router.ts` What happens in the previous case is: port exits and it returns to next. But if you are in development it cannot return to Next because there is no Next. So in script.py I put back in the render end page at the last steps. So it first tries to exit to Next, this will happen when running in next, but if not it renders a (useless thank you page). I put it back because otherwise it would lead to lots of confusion, researcher will think the app is stuck
- Footer is back and optional, the footer only has the skip button nothing else. 